### PR TITLE
Awandersleben05/pat 232 beginner friendly linter messages

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -16,7 +16,7 @@ COPY edits/pyflakes_lint.py /usr/local/lib/python3.11/site-packages/pylsp/plugin
 COPY edits/plugin.py /usr/local/lib/python3.11/site-packages/pylsp_ruff/plugin.py
 
 # Set the working directory to the pylsp_ruff package folder
-WORKDIR /usr/local/lib/python3.11/site-packages/pylsp_ruff
+# WORKDIR /usr/local/lib/python3.11/site-packages/pylsp_p
 
 # Expose port 8000 for WebSocket
 EXPOSE 8080

--- a/dockerfile
+++ b/dockerfile
@@ -15,9 +15,6 @@ COPY edits/jedi_completion.py /usr/local/lib/python3.11/site-packages/pylsp/plug
 COPY edits/pyflakes_lint.py /usr/local/lib/python3.11/site-packages/pylsp/plugins/pyflakes_lint.py
 COPY edits/plugin.py /usr/local/lib/python3.11/site-packages/pylsp_ruff/plugin.py
 
-# Set the working directory to the pylsp_ruff package folder
-# WORKDIR /usr/local/lib/python3.11/site-packages/pylsp_p
-
 # Expose port 8000 for WebSocket
 EXPOSE 8080
 

--- a/edits/plugin.py
+++ b/edits/plugin.py
@@ -46,6 +46,7 @@ NOQA_REGEX = re.compile(
     r"(?::\s?(?P<codes>([A-Z]+[0-9]+(?:[,\s]+)?)+))?"
 )
 
+#list of valid Patch functions to ignore
 CUSTOM_VALID_FUNCTIONS = [
     "move",
     "goToXY",
@@ -259,16 +260,17 @@ def pylsp_lint(workspace: Workspace, document: Document) -> List[Dict]:
     """
     settings = load_settings(workspace, document.path)
     checks = run_ruff_check(document=document, settings=settings)
+    # Only get diagnostics for valid errors, not Patch function errors
     diagnostics = []
     for c in checks:
         isError = True
+        #Checks if a naming error
         if (c.code == "F821"):
             for n in CUSTOM_VALID_FUNCTIONS:
                 if n in c.message:
                     isError = False
         if isError:
             diagnostics.append(create_diagnostic(check=c, settings=settings))
-    # diagnostics = [create_diagnostic(check=c, settings=settings) for c in checks]
     return converter.unstructure(diagnostics)
 
 

--- a/edits/plugin.py
+++ b/edits/plugin.py
@@ -46,6 +46,89 @@ NOQA_REGEX = re.compile(
     r"(?::\s?(?P<codes>([A-Z]+[0-9]+(?:[,\s]+)?)+))?"
 )
 
+CUSTOM_VALID_FUNCTIONS = [
+    "move",
+    "goToXY",
+    "goTo",
+    "turnRight",
+    "turnLeft",
+    "pointInDirection",
+    "pointTowards",
+    "glide",
+    "glideTo",
+    "ifOnEdgeBounce",
+    "setRotationStyle",
+    "changeX",
+    "setX",
+    "changeY",
+    "setY",
+    "getX",
+    "getY",
+    "getDirection",
+    "say",
+    "sayFor",
+    "think",
+    "thinkFor",
+    "show",
+    "hide",
+    "setCostumeTo",
+    "setBackdropTo",
+    "setBackdropToAndWait",
+    "nextCostume",
+    "nextBackdrop",
+    "changeGraphicEffectBy",
+    "setGraphicEffectTo",
+    "clearGraphicEffects",
+    "changeSizeBy",
+    "setSizeTo",
+    "setLayerTo",
+    "changeLayerBy",
+    "getSize",
+    "getCostume",
+    "getBackdrop",
+    "playSound",
+    "playSoundUntilDone",
+    "stopAllSounds",
+    "setSoundEffectTo",
+    "changeSoundEffectBy",
+    "clearSoundEffects",
+    "setVolumeTo",
+    "changeVolumeBy",
+    "getVolume",
+    "broadcast",
+    "broadcastAndWait",
+    "isTouching",
+    "isTouchingColor",
+    "isColorTouchingColor",
+    "distanceTo",
+    "getTimer",
+    "resetTimer",
+    "getAttributeOf",
+    "getMouseX",
+    "getMouseY",
+    "isMouseDown",
+    "isKeyPressed",
+    "current",
+    "daysSince2000",
+    "getLoudness",
+    "getUsername",
+    "ask",
+    "wait",
+    "stop",
+    "createClone",
+    "deleteClone",
+    "erasePen",
+    "stampPen",
+    "penDown",
+    "penUp",
+    "setPenColor",
+    "changePenEffect",
+    "setPenEffect",
+    "changePenSize",
+    "setPenSize",
+    "endThread"
+]
+
 
 UNNECESSITY_CODES = {
     "F401",  # `module` imported but unused
@@ -176,7 +259,16 @@ def pylsp_lint(workspace: Workspace, document: Document) -> List[Dict]:
     """
     settings = load_settings(workspace, document.path)
     checks = run_ruff_check(document=document, settings=settings)
-    diagnostics = [create_diagnostic(check=c, settings=settings) for c in checks]
+    diagnostics = []
+    for c in checks:
+        isError = True
+        if (c.code == "F821"):
+            for n in CUSTOM_VALID_FUNCTIONS:
+                if n in c.message:
+                    isError = False
+        if isError:
+            diagnostics.append(create_diagnostic(check=c, settings=settings))
+    # diagnostics = [create_diagnostic(check=c, settings=settings) for c in checks]
     return converter.unstructure(diagnostics)
 
 
@@ -230,6 +322,7 @@ def create_diagnostic(check: RuffCheck, settings: PluginSettings) -> Diagnostic:
     tags = []
     if check.code in UNNECESSITY_CODES:
         tags = [DiagnosticTag.Unnecessary]
+
 
     return Diagnostic(
         source=DIAGNOSTIC_SOURCE,

--- a/edits/pyflakes_lint.py
+++ b/edits/pyflakes_lint.py
@@ -213,7 +213,7 @@ class PyflakesDiagnosticReport:
                         c2 = next(it2)
                     except StopIteration: return True
         
-        msg = message.message % message.message_args
+        msg = ""
         # for m in PYTHON_KEY_WORDS:
         #     msg += str(m)
         errorName = message.message_args[0]
@@ -236,19 +236,19 @@ class PyflakesDiagnosticReport:
             checkSet = funs if isFun else vars
             if (checkSet.count(errorName) <= 1):
                 instructStr = "defining" if isFun else "assigning a value to"
-                msg += ". Try " + instructStr + " \'" + errorName + "\' before using it."
+                msg += "Try " + instructStr + " \'" + errorName + "\' before using it. "
             namesSet = set(checkSet).difference(set(CUSTOM_VALID_FUNCTIONS))
             namesSet.discard(errorName)
 
             #First check for misspelled builtin words
             for m in (CUSTOM_VALID_FUNCTIONS + PYTHON_FUNCTIONS if isFun else PYTHON_KEY_WORDS):
                 if (m.upper() == errorName.upper() or almost_equal(m, errorName)):
-                    msg += " Did you mean \'" + m + "\' instead of \'" + errorName + "\'?"
+                    msg += "Did you mean \'" + m + "\' instead of \'" + errorName + "\'? "
                     break
             #Then check if misspelled name
             for m in namesSet:
                 if (m.upper() == errorName.upper() or almost_equal(m, errorName)):
-                    msg += " Did you mean \'" + m + "\' instead of \'" + errorName + "\'?"
+                    msg += "Did you mean \'" + m + "\' instead of \'" + errorName + "\'? "
                     break
 
         self.diagnostics.append(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "python-lsp-server-docker",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This ticket fixes both the bug with errors not lasting and adds better error messages. Changes were made to Dockerfile, plugin.py, and pyflakes_lint.py. Now, ruff handles all python errors and pyflakes handles all custom helper messages.
![Screenshot 2024-06-06 at 9 09 44 AM](https://github.com/BX-Coding/python-lsp-server-docker/assets/78870469/60b20b95-cd62-4923-b7ca-cbde603cc759)
![Screenshot 2024-06-06 at 9 09 33 AM](https://github.com/BX-Coding/python-lsp-server-docker/assets/78870469/20d2f705-27f1-4656-a6af-21999c624780)
